### PR TITLE
[Feat] Support usernameless URI authentication

### DIFF
--- a/futuraedemoapp/build.gradle.kts
+++ b/futuraedemoapp/build.gradle.kts
@@ -114,7 +114,7 @@ android {
 dependencies {
     implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.6.3") // any version higher, requires Kotlin v2
     implementation("com.futurae.sdk:adaptive:1.1.1-alpha")
-    implementation("com.futurae.sdk:futuraekit-beta:3.6.1-beta")
+    implementation("com.futurae.sdk:futuraekit-beta:3.7.0-beta")
 
     // Refer to BOM mapping page to verify individual app versions used
     // https://developer.android.com/develop/ui/compose/bom/bom-mapping

--- a/futuraedemoapp/src/main/AndroidManifest.xml
+++ b/futuraedemoapp/src/main/AndroidManifest.xml
@@ -51,6 +51,7 @@
                 <data android:host="www.futurae.com"/>
                 <data android:pathPrefix="/futurae_enroll"/>
                 <data android:pathPrefix="/futurae_auth"/>
+                <data android:pathPrefix="/futurae_usernameless_auth"/>
             </intent-filter>
         </activity>
 

--- a/futuraedemoapp/src/main/java/com/futurae/demoapp/arch/AccountInput.kt
+++ b/futuraedemoapp/src/main/java/com/futurae/demoapp/arch/AccountInput.kt
@@ -1,0 +1,8 @@
+package com.futurae.demoapp.arch
+
+import com.futurae.sdk.public_api.common.model.FTAccount
+
+sealed class AccountInput {
+    data object Unspecified: AccountInput()
+    data class Specified(val account: FTAccount): AccountInput()
+}

--- a/futuraedemoapp/src/main/java/com/futurae/demoapp/arch/AuthRequestData.kt
+++ b/futuraedemoapp/src/main/java/com/futurae/demoapp/arch/AuthRequestData.kt
@@ -3,11 +3,13 @@ package com.futurae.demoapp.arch
 import com.futurae.sdk.public_api.auth.model.OnlineQR
 import com.futurae.sdk.public_api.auth.model.SessionIdentificationOption
 import com.futurae.sdk.public_api.auth.model.UsernamelessQR
+import com.futurae.sdk.public_api.auth.model.UsernamelessURI
 import com.futurae.sdk.public_api.common.model.FTAccount
 import com.futurae.sdk.public_api.qr_code.model.QRCode
 import com.futurae.sdk.public_api.session.model.ApproveSession
 import com.futurae.sdk.public_api.session.model.ByToken
 import com.futurae.sdk.public_api.session.model.SessionInfoQuery
+import com.futurae.sdk.public_api.uri.model.FTRUriType
 
 sealed class AuthRequestData {
 
@@ -27,20 +29,40 @@ sealed class AuthRequestData {
             OnlineQR(qrCodeContent = qrCode.rawCode)
     }
 
-    data class UsernamelessQRCode(
-        private val qrCode: QRCode.Usernameless,
-        val ftAccount: FTAccount
-    ): AuthRequestData() {
+    sealed class Usernameless: AuthRequestData() {
 
-        private val sessionToken = qrCode.sessionToken
+        protected abstract val sessionToken: String
 
-        val sessionInfoQuery: SessionInfoQuery = SessionInfoQuery(
-            ByToken(sessionToken),
-            ftAccount.userId
+        abstract fun getSessionIdentificationOption(account: FTAccount): SessionIdentificationOption
+
+        fun getSessionInfoQuery(account: FTAccount): SessionInfoQuery = SessionInfoQuery(
+            sessionIdentifier = ByToken(sessionToken),
+            userId = account.userId
         )
 
-        val sessionIdentificationOption: SessionIdentificationOption =
-            UsernamelessQR(userId = ftAccount.userId, qrCodeContent = qrCode.rawCode)
+        data class QR(private val qrCode: QRCode.Usernameless): Usernameless() {
+
+            override val sessionToken = qrCode.sessionToken
+
+            override fun getSessionIdentificationOption(
+                account: FTAccount
+            ): SessionIdentificationOption = UsernamelessQR(
+                userId = account.userId,
+                qrCodeContent = qrCode.rawCode
+            )
+        }
+
+        data class URI(val ftrUriType: FTRUriType.UsernamelessAuth) : Usernameless() {
+
+            override val sessionToken = ftrUriType.sessionToken
+
+            override fun getSessionIdentificationOption(
+                account: FTAccount
+            ): SessionIdentificationOption = UsernamelessURI(
+                userId = account.userId,
+                uri = ftrUriType.uri
+            )
+        }
     }
 
     data class OfflineQRCode(

--- a/futuraedemoapp/src/main/java/com/futurae/demoapp/home/qrscanner/QRScannerScreen.kt
+++ b/futuraedemoapp/src/main/java/com/futurae/demoapp/home/qrscanner/QRScannerScreen.kt
@@ -51,8 +51,7 @@ import kotlinx.coroutines.launch
 fun QRScannerScreen(
     onInvalidQRCode: () -> Unit,
     onEnrollmentRequest: (EnrollmentCase.QRCodeScan) -> Unit,
-    onAuthRequest: (AuthRequestData) -> Unit,
-    showAccountPicker: (String) -> Unit
+    onAuthRequest: (AuthRequestData) -> Unit
 ) {
     val qrScannerViewModel: QRScannerViewModel = viewModel(
         factory = QRScannerViewModel.provideFactory()
@@ -96,10 +95,6 @@ fun QRScannerScreen(
         if (isPermissionPermanentlyDenied) {
             showGoToSettingsDialog = true
         }
-
-        qrScannerViewModel.showAccountPicker
-            .onEach { showAccountPicker(it) }
-            .launchIn(this)
 
         qrScannerViewModel.onAuthRequest
             .onEach { onAuthRequest(it) }

--- a/futuraedemoapp/src/main/java/com/futurae/demoapp/home/qrscanner/arch/QRScannerViewModel.kt
+++ b/futuraedemoapp/src/main/java/com/futurae/demoapp/home/qrscanner/arch/QRScannerViewModel.kt
@@ -23,9 +23,6 @@ class QRScannerViewModel : ViewModel() {
         }
     }
 
-    private val _showAccountPicker = MutableSharedFlow<String>()
-    val showAccountPicker: SharedFlow<String> = _showAccountPicker
-
     private val _onAuthRequest = MutableSharedFlow<AuthRequestData>()
     val onAuthRequest: SharedFlow<AuthRequestData> = _onAuthRequest
 
@@ -76,9 +73,8 @@ class QRScannerViewModel : ViewModel() {
     }
 
     private fun QRCode.Usernameless.handleUsernamelessQRCodeScanned() {
-        viewModelScope.launch {
-            _showAccountPicker.emit(this@handleUsernamelessQRCodeScanned.rawCode)
-        }
+        val authRequestData = AuthRequestData.Usernameless.QR(qrCode = this)
+        notifyForAuthRequest(authRequestData)
     }
 
     private fun notifyUserForInvalidQRCodeScanned() {

--- a/futuraedemoapp/src/main/java/com/futurae/demoapp/settings/debug/uriutils/DebugURIUtilsViewModel.kt
+++ b/futuraedemoapp/src/main/java/com/futurae/demoapp/settings/debug/uriutils/DebugURIUtilsViewModel.kt
@@ -118,12 +118,19 @@ class DebugURIUtilsViewModel: ViewModel() {
             )
         }
 
-        FTRUriType.Unknown -> {
+        is FTRUriType.Unknown -> {
             URIHandlingResult(
                 type = URI.UNKNOWN,
                 extractedInfo = emptyMap()
             )
         }
+
+        is FTRUriType.UsernamelessAuth -> URIHandlingResult(
+            type = URI.AUTH,
+            extractedInfo = mapOf(
+                "sessionToken" to result.sessionToken
+            )
+        )
     }
 
     sealed class DebugURIUtilsUIState {


### PR DESCRIPTION
## Summary ✍️ 
This MR adds support for usernameless URI-based authentication, enabling authentication flow without requiring a predefined user.
We now support two types of usernameless URIs:
- Custom mobile scheme: `futurae://futurae_usernameless_auth?...`
- Universal link: `https://futurae.com/futurae_usernameless_auth?...`

## Changes 📓 

- Updated manifest to support the new path_prefix on our URIs.
- Updated AccountPicker to not expect any info related to scanned usernameless QR to be reused on usernameless URI as well.
- Updated AuthRequestData to consider both usernameless QR codes and usernameless URIs.
- Updated QRScannerScreen to delegate handling of usernameless QR code to AuthenticationViewModel instead of navigating to AccountPicker.
- Updated FuturaeViewModel to delegate handling of usernameless URI to AuthenticationViewModel.
- Updated AuthenticationViewModel to handle usernameless authentication either URI-based or QR-based. AuthenticationViewModel is also responsible to prompt user pick an Account through AccountPicker prior initiating the authentication flow.