### PR TITLE
[Release] Update for v3.7.1-beta

### DIFF
--- a/futuraeSampleApp/build.gradle.kts
+++ b/futuraeSampleApp/build.gradle.kts
@@ -117,7 +117,7 @@ android {
 dependencies {
     implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.6.3") // any version higher, requires Kotlin v2
     implementation("com.futurae.sdk:adaptive:1.1.1-alpha")
-    implementation("com.futurae.sdk:futuraekit-beta:3.7.0-beta")
+    implementation("com.futurae.sdk:futuraekit-beta:3.7.1-beta")
 
     // Refer to BOM mapping page to verify individual app versions used
     // https://developer.android.com/develop/ui/compose/bom/bom-mapping


### PR DESCRIPTION
**📓 Summary**

Since we released new version of Futurae SDK [v3.7.1-beta](https://github.com/Futurae-Technologies/android-sdk-beta/releases/tag/v3.7.1-beta), this PR bumps the Futurae SDK version to latest.