### PR TITLE
Chore: configure WindowManager.LayoutParams.FLAG_SECURE only for prod builds

### DIFF
--- a/futuraeSampleApp/build.gradle.kts
+++ b/futuraeSampleApp/build.gradle.kts
@@ -64,6 +64,7 @@ android {
             manifestPlaceholders["appNameSuffix"] = " DEV"
             signingConfig = signingConfigs.getByName("debug")
             resValue("string", "app_name", "SampleDebug")
+            buildConfigField("Boolean", "ENABLE_SECURE_WINDOW", "false")
         }
 
         create("qa") {
@@ -72,6 +73,7 @@ android {
             signingConfig = signingConfigs.getByName("debug")
             matchingFallbacks += listOf("release", "debug")
             resValue("string", "app_name", "SampleQA")
+            buildConfigField("Boolean", "ENABLE_SECURE_WINDOW", "false")
         }
 
         getByName("release") {
@@ -79,6 +81,7 @@ android {
             applicationIdSuffix = ".prod"
             signingConfig = signingConfigs.getByName("debug")
             resValue("string", "app_name", "Sample")
+            buildConfigField("Boolean", "ENABLE_SECURE_WINDOW", "true")
         }
     }
 

--- a/futuraeSampleApp/src/main/java/com/futurae/sampleapp/MainActivity.kt
+++ b/futuraeSampleApp/src/main/java/com/futurae/sampleapp/MainActivity.kt
@@ -48,10 +48,12 @@ class MainActivity : FragmentActivity(), DefaultLifecycleObserver {
     }
 
     override fun onCreate(savedInstanceState: Bundle?) {
-        window.setFlags(
-            WindowManager.LayoutParams.FLAG_SECURE,
-            WindowManager.LayoutParams.FLAG_SECURE
-        )
+        if(BuildConfig.ENABLE_SECURE_WINDOW) {
+            window.setFlags(
+                WindowManager.LayoutParams.FLAG_SECURE,
+                WindowManager.LayoutParams.FLAG_SECURE
+            )
+        }
         enableEdgeToEdge()
         super<FragmentActivity>.onCreate(savedInstanceState)
         setContent {


### PR DESCRIPTION
### Changelog
- Declare Boolean buildConfigField `ENABLE_SECURE_WINDOW` as false for debug and QA builds, true for release builds.
- Update `MainActivity` to set `WindowManager.LayoutParams.FLAG_SECURE` only when above flag is true.