### PR TITLE
[Bug] Unenroll notification display

### DIFF
--- a/futuraeSampleApp/src/main/AndroidManifest.xml
+++ b/futuraeSampleApp/src/main/AndroidManifest.xml
@@ -59,7 +59,7 @@
         </activity>
 
         <service
-            android:name="com.futurae.sdk.messaging.FTRFcmMessagingService"
+            android:name=".services.FuturaeDemoFirebaseService"
             android:exported="false">
 
             <intent-filter>

--- a/futuraeSampleApp/src/main/java/com/futurae/sampleapp/FuturaeDemoApp.kt
+++ b/futuraeSampleApp/src/main/java/com/futurae/sampleapp/FuturaeDemoApp.kt
@@ -1,14 +1,93 @@
 package com.futurae.sampleapp
 
+import android.Manifest
 import android.app.Application
+import android.content.pm.PackageManager.PERMISSION_GRANTED
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.ProcessLifecycleOwner
+import com.futurae.sampleapp.arch.NotificationType
+import com.futurae.sampleapp.arch.NotificationUI
+import com.futurae.sampleapp.ui.TextWrapper
+import com.futurae.sampleapp.ui.shared.elements.alertdialog.FuturaeAlertDialogUIState
 import com.futurae.sampleapp.utils.LocalStorage
+import com.futurae.sampleapp.utils.NotificationHelper
+import com.futurae.sdk.FuturaeSDK
+import com.futurae.sdk.messaging.FTRNotificationEvent
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.launch
 import timber.log.Timber
 
 class FuturaeSampleApplication : Application() {
+
+    private val coroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
 
     override fun onCreate() {
         super.onCreate()
         Timber.plant(Timber.DebugTree())
         LocalStorage.init(applicationContext)
+        coroutineScope.launch {
+            FuturaeSDK.notificationsFlow
+                .onEach { result ->
+                    result
+                        .onSuccess { event ->
+                            if (!isAppInForeground()) {
+                                showSystemNotificationForEvent(event)
+                            }
+                        }
+                        .onFailure {
+                            Timber.e("Notification Flow failure: $it")
+                        }
+                }
+                .collect()
+        }
+    }
+
+    private fun showSystemNotificationForEvent(event: FTRNotificationEvent) {
+        if (checkSelfPermission(Manifest.permission.POST_NOTIFICATIONS) != PERMISSION_GRANTED) return
+        val notificationUI = event.toNotificationUI() ?: return
+        NotificationHelper.showNotification(applicationContext, notificationUI)
+    }
+
+    private fun FTRNotificationEvent.toNotificationUI(): NotificationUI? = when (this) {
+        is FTRNotificationEvent.Authentication -> NotificationUI(
+            type = NotificationType.AUTH,
+            dialogState = FuturaeAlertDialogUIState(
+                title = TextWrapper.Resource(R.string.sdk_notification_auth_title),
+                text = TextWrapper.Resource(R.string.sdk_notification_auth_body),
+                confirmButtonCta = TextWrapper.Resource(R.string.ok),
+            ),
+            timeoutEpochMs = session.timeout * 1000L
+        )
+        is FTRNotificationEvent.AccountUnenrollment -> NotificationUI(
+            type = NotificationType.UNENROLL,
+            dialogState = FuturaeAlertDialogUIState(
+                title = TextWrapper.Resource(R.string.sdk_notification_unenroll_title),
+                text = TextWrapper.Resource(
+                    R.string.sdk_notification_unenroll_body,
+                    listOf(userId)
+                ),
+                confirmButtonCta = TextWrapper.Resource(R.string.ok),
+            )
+        )
+        is FTRNotificationEvent.QRCodeScanRequest -> NotificationUI(
+            type = NotificationType.QR_SCAN,
+            dialogState = FuturaeAlertDialogUIState(
+                title = TextWrapper.Resource(R.string.sdk_qr_scan_notification_title),
+                text = TextWrapper.Resource(
+                    R.string.sdk_qr_scan_notification_body,
+                    listOf(userId)
+                ),
+                confirmButtonCta = TextWrapper.Resource(R.string.ok),
+            )
+        )
+        is FTRNotificationEvent.CustomInAppMessaging -> null
+    }
+
+    private fun isAppInForeground(): Boolean {
+        return ProcessLifecycleOwner.get().lifecycle.currentState.isAtLeast(Lifecycle.State.STARTED)
     }
 }

--- a/futuraeSampleApp/src/main/java/com/futurae/sampleapp/MainActivity.kt
+++ b/futuraeSampleApp/src/main/java/com/futurae/sampleapp/MainActivity.kt
@@ -1,8 +1,6 @@
 package com.futurae.sampleapp
 
-import android.Manifest
 import android.content.Intent
-import android.content.pm.PackageManager.PERMISSION_GRANTED
 import android.os.Bundle
 import android.view.WindowManager
 import androidx.activity.compose.setContent
@@ -16,10 +14,8 @@ import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.semantics.testTagsAsResourceId
 import androidx.fragment.app.FragmentActivity
 import androidx.lifecycle.DefaultLifecycleObserver
-import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.ProcessLifecycleOwner
-import androidx.lifecycle.lifecycleScope
 import com.futurae.sampleapp.accountsrecovery.check.arch.AccountsRecoveryCheckViewModel
 import com.futurae.sampleapp.arch.FuturaeViewModel
 import com.futurae.sampleapp.arch.PinProviderViewModel
@@ -32,8 +28,6 @@ import com.futurae.sampleapp.utils.LocalStorage
 import com.futurae.sampleapp.utils.NotificationHelper
 import com.futurae.sdk.FuturaeSDK
 import com.futurae.sdk.public_api.common.LockConfigurationType
-import kotlinx.coroutines.launch
-import timber.log.Timber
 
 class MainActivity : FragmentActivity(), DefaultLifecycleObserver {
 
@@ -65,26 +59,7 @@ class MainActivity : FragmentActivity(), DefaultLifecycleObserver {
 
         handleIntent(intent)
 
-        // Observe here so we can collect even when app is in the background
-        lifecycleScope.launch {
-            futuraeViewModel.notifyUserFlow.collect {
-                if (isAppInForeground()) {
-                    // Let compose navigation graph handle it
-                } else {
-                    if (checkSelfPermission(Manifest.permission.POST_NOTIFICATIONS) == PERMISSION_GRANTED) {
-                        NotificationHelper.showNotification(this@MainActivity, it)
-                    } else {
-                        Timber.w("POST_NOTIFICATIONS not granted. Cannot display push notification")
-                    }
-                }
-            }
-        }
-
         ProcessLifecycleOwner.get().lifecycle.addObserver(this)
-    }
-
-    private fun isAppInForeground(): Boolean {
-        return ProcessLifecycleOwner.get().lifecycle.currentState.isAtLeast(Lifecycle.State.STARTED)
     }
 
     override fun onStop(owner: LifecycleOwner) {
@@ -110,8 +85,8 @@ class MainActivity : FragmentActivity(), DefaultLifecycleObserver {
         intent.extras?.let { extras ->
             val keys = extras.keySet()
             if (keys.any { it == NotificationHelper.EXTRA_AUTH || it == NotificationHelper.EXTRA_UNENROLL }){
-                // perform account refresh
-                futuraeViewModel.fetchAccountsStatus()
+                // perform account refresh, deferring until SDK is ready if needed
+                futuraeViewModel.scheduleAccountStatusFetch()
             } else if (keys.any { it == NotificationHelper.EXTRA_QR }) {
                 // navigate to QR
             }

--- a/futuraeSampleApp/src/main/java/com/futurae/sampleapp/arch/FuturaeViewModel.kt
+++ b/futuraeSampleApp/src/main/java/com/futurae/sampleapp/arch/FuturaeViewModel.kt
@@ -307,30 +307,21 @@ class FuturaeViewModel(
     }
 
     private fun onAccountUnenroll(notification: FTRNotificationEvent.AccountUnenrollment) {
-        FuturaeSDK.client.accountApi
-            .getAccount(
-                accountQuery = AccountQuery.WhereUserIdAndDevice(
-                    userId = notification.userId,
-                    deviceId = notification.deviceId
+        viewModelScope.launch {
+            _notifyUser.emit(
+                NotificationUI(
+                    type = NotificationType.UNENROLL,
+                    dialogState = FuturaeAlertDialogUIState(
+                        title = TextWrapper.Resource(R.string.sdk_notification_unenroll_title),
+                        text = TextWrapper.Resource(
+                            R.string.sdk_notification_unenroll_body,
+                            listOf(notification.userId)
+                        ),
+                        confirmButtonCta = TextWrapper.Resource(R.string.ok),
+                    )
                 )
             )
-            ?.let {
-                viewModelScope.launch {
-                    _notifyUser.emit(
-                        NotificationUI(
-                            type = NotificationType.UNENROLL,
-                            dialogState = FuturaeAlertDialogUIState(
-                                title = TextWrapper.Resource(R.string.sdk_notification_unenroll_title),
-                                text = TextWrapper.Resource(
-                                    R.string.sdk_notification_unenroll_body,
-                                    listOf(it.userId)
-                                ),
-                                confirmButtonCta = TextWrapper.Resource(R.string.ok),
-                            )
-                        )
-                    )
-                }
-            }
+        }
     }
 
     private fun handleApproveAuth(authenticationSessionData: FTRNotificationEvent.Authentication) {

--- a/futuraeSampleApp/src/main/java/com/futurae/sampleapp/arch/FuturaeViewModel.kt
+++ b/futuraeSampleApp/src/main/java/com/futurae/sampleapp/arch/FuturaeViewModel.kt
@@ -65,6 +65,7 @@ class FuturaeViewModel(
 
     private var pendingUri: String? = null
     private var pendingBroadcastReceivedMessage: FTRNotificationEvent? = null
+    private var pendingNotificationAccountFetch: Boolean = false
 
     private var getAccountStatus: Job? = null
 
@@ -76,8 +77,17 @@ class FuturaeViewModel(
                 .collect {
                     checkForPendingURI()
                     checkForPendingBroadcastReceivedMessage()
+                    checkForPendingNotificationAccountFetch()
                 }
         }
+    }
+
+    fun scheduleAccountStatusFetch() {
+        if (!FuturaeSDK.isSDKInitialized || FuturaeSDK.client.lockApi.isLocked()) {
+            pendingNotificationAccountFetch = true
+            return
+        }
+        fetchAccountsStatus()
     }
 
     fun fetchAccountsStatus() {
@@ -222,6 +232,13 @@ class FuturaeViewModel(
         }
     }
 
+    private fun checkForPendingNotificationAccountFetch() {
+        if (pendingNotificationAccountFetch) {
+            pendingNotificationAccountFetch = false
+            fetchAccountsStatus()
+        }
+    }
+
     private fun handleUri(uri: String) {
         when (val ftrUriType = FTUriUtils.getFTRUriType(uri)) {
             is FTRUriType.Auth -> handleAuthenticationURI(ftrUriType)
@@ -340,7 +357,8 @@ class FuturaeViewModel(
                         title = TextWrapper.Resource(R.string.sdk_notification_auth_title),
                         text = TextWrapper.Resource(R.string.sdk_notification_auth_body),
                         confirmButtonCta = TextWrapper.Resource(R.string.ok),
-                    )
+                    ),
+                    timeoutEpochMs = authenticationSessionData.session.timeout * 1000L
                 )
             )
         }

--- a/futuraeSampleApp/src/main/java/com/futurae/sampleapp/arch/NotificationUI.kt
+++ b/futuraeSampleApp/src/main/java/com/futurae/sampleapp/arch/NotificationUI.kt
@@ -11,6 +11,7 @@ enum class NotificationType {
 }
 
 data class NotificationUI(
-    val type : NotificationType,
-    val dialogState: FuturaeAlertDialogUIState
+    val type: NotificationType,
+    val dialogState: FuturaeAlertDialogUIState,
+    val timeoutEpochMs: Long? = null
 )

--- a/futuraeSampleApp/src/main/java/com/futurae/sampleapp/services/FuturaeDemoFirebaseService.kt
+++ b/futuraeSampleApp/src/main/java/com/futurae/sampleapp/services/FuturaeDemoFirebaseService.kt
@@ -10,6 +10,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
 import java.util.concurrent.CancellationException
 
 class FuturaeDemoFirebaseService : FirebaseMessagingService() {
@@ -20,19 +21,21 @@ class FuturaeDemoFirebaseService : FirebaseMessagingService() {
     override fun onMessageReceived(message: RemoteMessage) {
         super.onMessageReceived(message)
 
-        coroutineScope.launch {
+        // hacky/risky to use runBlocking + Dispatchers.Main but necessary to show notifications while the app is killed.
+        // using a coroutine (async job) means the current FCM service may be killed before the coroutine completes.
+        runBlocking(Dispatchers.Main) {
             val sdkStatus = FuturaeSDK.sdkState().value.status
             if (sdkStatus == FuturaeSDKStatus.Uninitialized) {
                 val hasSdkLaunchedSuccessfully = SdkWrapper.attemptToLaunchSDKSilently(application)
                 if (!hasSdkLaunchedSuccessfully) {
-                    return@launch
+                    return@runBlocking
                 }
             } else if (sdkStatus is FuturaeSDKStatus.Corrupted) {
                 // Todo handle this
+                return@runBlocking
             }
 
-            val messageData = message.data
-            FuturaeSDK.client.operationsApi.handlePushNotification(messageData)
+            FuturaeSDK.client.operationsApi.handlePushNotification(message.data)
         }
     }
 

--- a/futuraeSampleApp/src/main/java/com/futurae/sampleapp/utils/NotificationHelper.kt
+++ b/futuraeSampleApp/src/main/java/com/futurae/sampleapp/utils/NotificationHelper.kt
@@ -10,6 +10,12 @@ import com.futurae.sampleapp.MainActivity
 import com.futurae.sampleapp.R
 import com.futurae.sampleapp.arch.NotificationType
 import com.futurae.sampleapp.arch.NotificationUI
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import kotlin.time.Duration.Companion.milliseconds
 
 object NotificationHelper {
 
@@ -19,16 +25,17 @@ object NotificationHelper {
     private const val CHANNEL_ID = "futurae"
     private const val CHANNEL_NAME = "Futurae"
     private const val CHANNEL_DESC = "Futurae Push Notifications"
+    private const val NOTIFICATION_ID = 1
+
+    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Main)
 
     fun showNotification(context: Context, notificationUI: NotificationUI) {
-        val notificationId = 1
+        val notificationManager =
+            context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
 
-        val importance = NotificationManager.IMPORTANCE_DEFAULT
-        val channel = NotificationChannel(CHANNEL_ID, CHANNEL_NAME, importance).apply {
+        val channel = NotificationChannel(CHANNEL_ID, CHANNEL_NAME, NotificationManager.IMPORTANCE_DEFAULT).apply {
             description = CHANNEL_DESC
         }
-        val notificationManager: NotificationManager =
-            context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
         notificationManager.createNotificationChannel(channel)
 
         val intent = Intent(context, MainActivity::class.java).apply {
@@ -47,16 +54,31 @@ object NotificationHelper {
             context,
             0,
             intent,
-            PendingIntent.FLAG_UPDATE_CURRENT or
-                    PendingIntent.FLAG_IMMUTABLE
+            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
         )
-        val notificationBuilder = Notification.Builder(context, CHANNEL_ID)
+        val notification = Notification.Builder(context, CHANNEL_ID)
             .setContentTitle(notificationUI.dialogState.title.value(context))
             .setSmallIcon(R.drawable.ic_launcher_foreground)
             .setContentText(notificationUI.dialogState.text.value(context))
             .setPriority(Notification.PRIORITY_DEFAULT)
             .setContentIntent(pendingIntent)
+            .setAutoCancel(true)
+            .build()
 
-        notificationManager.notify(notificationId, notificationBuilder.build())
+        notificationManager.notify(NOTIFICATION_ID, notification)
+
+        notificationUI.timeoutEpochMs?.let { timeoutEpochMs ->
+            scope.launch {
+                val delayMs = timeoutEpochMs - System.currentTimeMillis()
+                if (delayMs > 0) delay(delayMs.milliseconds)
+                cancelNotification(context.applicationContext, NOTIFICATION_ID)
+            }
+        }
+    }
+
+    fun cancelNotification(context: Context, notificationId: Int) {
+        val notificationManager =
+            context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+        notificationManager.cancel(notificationId)
     }
 }


### PR DESCRIPTION
Fix UX issue that didn't display unenroll push notification. Sample app was checking that the user id on notification's payload was indeed a registered user on our device prior displaying the notification. However, this would never be valid, since the sdk internally handles the removal of the associated account from the active once prior delegating this notification to host app. 