### PR TITLE
Display unenroll push notification to user

### DIFF
--- a/futuraeSampleApp/src/main/java/com/futurae/sampleapp/arch/FuturaeViewModel.kt
+++ b/futuraeSampleApp/src/main/java/com/futurae/sampleapp/arch/FuturaeViewModel.kt
@@ -242,30 +242,21 @@ class FuturaeViewModel(
     }
 
     private fun onAccountUnenroll(notification: FTRNotificationEvent.AccountUnenrollment) {
-        FuturaeSDK.client.accountApi
-            .getAccount(
-                accountQuery = AccountQuery.WhereUserIdAndDevice(
-                    userId = notification.userId,
-                    deviceId = notification.deviceId
+        viewModelScope.launch {
+            _notifyUser.emit(
+                NotificationUI(
+                    type = NotificationType.UNENROLL,
+                    dialogState = FuturaeAlertDialogUIState(
+                        title = TextWrapper.Resource(R.string.sdk_notification_unenroll_title),
+                        text = TextWrapper.Resource(
+                            R.string.sdk_notification_unenroll_body,
+                            listOf(notification.userId)
+                        ),
+                        confirmButtonCta = TextWrapper.Resource(R.string.ok),
+                    )
                 )
             )
-            ?.let {
-                viewModelScope.launch {
-                    _notifyUser.emit(
-                        NotificationUI(
-                            type = NotificationType.UNENROLL,
-                            dialogState = FuturaeAlertDialogUIState(
-                                title = TextWrapper.Resource(R.string.sdk_notification_unenroll_title),
-                                text = TextWrapper.Resource(
-                                    R.string.sdk_notification_unenroll_body,
-                                    listOf(it.userId)
-                                ),
-                                confirmButtonCta = TextWrapper.Resource(R.string.ok),
-                            )
-                        )
-                    )
-                }
-            }
+        }
     }
 
     private fun handleApproveAuth(authenticationSessionData: FTRNotificationEvent.Authentication) {


### PR DESCRIPTION
Fix UX issue that didn't display unenroll push notification. Sample app was checking that the user id on notification's payload was indeed a registered user on our device prior displaying the notification. However, this would never be valid, since the sdk internally handles the removal of the associated account from the active once prior delegating this notification to host app.