### PR TITLE
[Feature] Support app2app enrollment flow

### DIFF
--- a/futuraeSampleApp/build.gradle.kts
+++ b/futuraeSampleApp/build.gradle.kts
@@ -131,6 +131,7 @@ dependencies {
     implementation("com.google.code.gson:gson:2.11.0")
 
     // Third-party
+    implementation("com.google.zxing:core:3.5.3")
     implementation("com.jakewharton.timber:timber:5.0.1")
     implementation("io.coil-kt:coil-compose:2.7.0")
     implementation("io.github.chaosleung:pinview:1.4.4")

--- a/futuraeSampleApp/src/main/java/com/futurae/sampleapp/home/accounts/AccountsScreen.kt
+++ b/futuraeSampleApp/src/main/java/com/futurae/sampleapp/home/accounts/AccountsScreen.kt
@@ -17,6 +17,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.HorizontalDivider
@@ -24,6 +25,7 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
@@ -33,6 +35,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.asImageBitmap
 import androidx.compose.ui.platform.LocalClipboardManager
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
@@ -49,6 +52,7 @@ import androidx.lifecycle.LifecycleEventObserver
 import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel
+import com.futurae.sdk.public_api.operations.model.EnrollmentExchangeTokenQrCode
 import com.futurae.sampleapp.R
 import com.futurae.sampleapp.TestTags
 import com.futurae.sampleapp.arch.FuturaeViewModel
@@ -88,6 +92,8 @@ fun AccountsScreen(
     val restoreAccountsBannerUIState by accountsViewModel.restorationBannerUIState.collectAsStateWithLifecycle()
     val timeoutProgress by accountsViewModel.timeoutCountdownProgress.collectAsStateWithLifecycle()
 
+    val enrollmentQrCode by accountsViewModel.enrollmentQrCode.collectAsStateWithLifecycle()
+
     AccountsScreen(
         uiState = uiState,
         timeoutProgress = timeoutProgress,
@@ -95,12 +101,20 @@ fun AccountsScreen(
         onAccountClick = onAccountClick,
         onHOTPRequest = accountsViewModel::getHOTP,
         onDeleteAccountRequest = accountsViewModel::deleteAccount,
+        onInitiateApp2AppEnrollment = accountsViewModel::initiateApp2AppEnrollment,
         onAccountRestorationBannerDismiss = accountsViewModel::accountsRestorationBannerDismissed,
         onRestoreAccountsClick = {
             accountsViewModel.userHasBeenInformed()
             onAccountRestorationClick(it)
         }
     )
+
+    enrollmentQrCode?.let { qr ->
+        EnrollmentQrCodeDialog(
+            qrCode = qr,
+            onDismiss = accountsViewModel::dismissEnrollmentQrCode
+        )
+    }
 
     LaunchedEffect(Unit) {
         accountsViewModel.onHOTPGenerated
@@ -109,6 +123,10 @@ fun AccountsScreen(
 
         accountsRecoveryCheckViewModel.migrationInfo
             .onEach { accountsViewModel.onMigrationInfoChanges(it) }
+            .launchIn(this)
+
+        accountsViewModel.onApp2AppEnrollmentInitiated
+            .onEach { clipboardManager.setText(AnnotatedString(it)) }
             .launchIn(this)
     }
 
@@ -134,6 +152,7 @@ private fun AccountsScreen(
     onAccountClick: (String) -> Unit,
     onHOTPRequest: (String) -> Unit,
     onDeleteAccountRequest: (String) -> Unit,
+    onInitiateApp2AppEnrollment: (String) -> Unit,
     onAccountRestorationBannerDismiss: () -> Unit,
     onRestoreAccountsClick: (Boolean) -> Unit
 ) {
@@ -144,7 +163,8 @@ private fun AccountsScreen(
                 timeoutProgress = timeoutProgress,
                 onAccountClick = onAccountClick,
                 onHOTPRequest = onHOTPRequest,
-                onDeleteAccountRequest = onDeleteAccountRequest
+                onDeleteAccountRequest = onDeleteAccountRequest,
+                onInitiateApp2AppEnrollment = onInitiateApp2AppEnrollment
             )
         } else {
             NoneEnrolledAccountScreen(
@@ -178,6 +198,7 @@ private fun AccountList(
     timeoutProgress: Float,
     onAccountClick: (String) -> Unit,
     onHOTPRequest: (String) -> Unit,
+    onInitiateApp2AppEnrollment: (String) -> Unit,
     onDeleteAccountRequest: (String) -> Unit
 ) {
     var lockedAccountInformativeDialog by remember {
@@ -201,6 +222,7 @@ private fun AccountList(
                 onClick = onAccountClick,
                 onHOTPRequest = onHOTPRequest,
                 onDeleteAccountRequest = onDeleteAccountRequest,
+                onInitiateApp2AppEnrollment = onInitiateApp2AppEnrollment,
                 onLockedAccountIconClicked = { dialogUIState ->
                     lockedAccountInformativeDialog = dialogUIState
                 }
@@ -228,6 +250,7 @@ private fun AccountItem(
     onClick: (String) -> Unit,
     onHOTPRequest: (String) -> Unit,
     onDeleteAccountRequest: (String) -> Unit,
+    onInitiateApp2AppEnrollment: (String) -> Unit,
     onLockedAccountIconClicked: (FuturaeAlertDialogUIState) -> Unit
 ) {
     var showAccountActions by remember { mutableStateOf(false) }
@@ -292,6 +315,10 @@ private fun AccountItem(
                             onDeleteAccountRequest = {
                                 onDeleteAccountRequest(uiState.userId)
                                 showAccountActions = false
+                            },
+                            onInitiateApp2AppEnrollment = {
+                                onInitiateApp2AppEnrollment(uiState.userId)
+                                showAccountActions = false
                             }
                         )
                     }
@@ -318,6 +345,10 @@ private fun AccountItem(
                                 onDeleteAccountRequest = {
                                     onDeleteAccountRequest(uiState.userId)
                                     showAccountActions = false
+                                },
+                                onInitiateApp2AppEnrollment = {
+                                    onInitiateApp2AppEnrollment(uiState.userId)
+                                    showAccountActions = false
                                 }
                             )
                         }
@@ -335,7 +366,8 @@ private fun AccountActionsPopup(
     isAccountLocked: Boolean,
     onHOTPRequest: () -> Unit,
     onDeleteAccountRequest: () -> Unit,
-    onDismissPopup: () -> Unit
+    onDismissPopup: () -> Unit,
+    onInitiateApp2AppEnrollment: () -> Unit
 ) {
     val context = LocalContext.current
     DropdownMenu(
@@ -366,7 +398,82 @@ private fun AccountActionsPopup(
             },
             onClick = onDeleteAccountRequest
         )
+        DropdownMenuItem(
+            contentPadding = PaddingValues(vertical = 2.dp, horizontal = 8.dp),
+            text = {
+                Text(
+                    text = TextWrapper
+                        .Resource(R.string.initiate_app2app_enrollment)
+                        .value(context),
+                    color = PrimaryColor
+                )
+            },
+            onClick = onInitiateApp2AppEnrollment
+        )
     }
+}
+
+@Composable
+private fun EnrollmentQrCodeDialog(
+    qrCode: EnrollmentExchangeTokenQrCode,
+    onDismiss: () -> Unit,
+) {
+    val bitmap = remember(qrCode.qrCode) {
+        runCatching {
+            val content = qrCode.qrCode
+            val size = 512
+            val bitMatrix = com.google.zxing.MultiFormatWriter()
+                .encode(content, com.google.zxing.BarcodeFormat.QR_CODE, size, size)
+            android.graphics.Bitmap.createBitmap(size, size, android.graphics.Bitmap.Config.RGB_565).apply {
+                for (x in 0 until size) {
+                    for (y in 0 until size) {
+                        setPixel(x, y, if (bitMatrix[x, y]) android.graphics.Color.BLACK else android.graphics.Color.WHITE)
+                    }
+                }
+            }.asImageBitmap()
+        }.getOrNull()
+    }
+
+    AlertDialog(
+        containerColor = OnPrimaryColor,
+        onDismissRequest = onDismiss,
+        title = {
+            Text(
+                text = "Scan QR Code",
+                style = FuturaeTypography.titleH4,
+                color = PrimaryColor
+            )
+        },
+        text = {
+            Column(
+                horizontalAlignment = Alignment.CenterHorizontally,
+                modifier = Modifier.fillMaxWidth()
+            ) {
+                if (bitmap != null) {
+                    Image(
+                        bitmap = bitmap,
+                        contentDescription = "Enrollment QR code",
+                        modifier = Modifier.size(240.dp)
+                    )
+                } else {
+                    Text(
+                        text = "Unable to render QR code",
+                        style = FuturaeTypography.bodySmallRegular,
+                        color = PrimaryColor
+                    )
+                }
+            }
+        },
+        confirmButton = {
+            TextButton(onClick = onDismiss) {
+                Text(
+                    text = "Close",
+                    style = FuturaeTypography.button,
+                    color = PrimaryColor
+                )
+            }
+        }
+    )
 }
 
 @Composable

--- a/futuraeSampleApp/src/main/java/com/futurae/sampleapp/home/accounts/arch/AccountsViewModel.kt
+++ b/futuraeSampleApp/src/main/java/com/futurae/sampleapp/home/accounts/arch/AccountsViewModel.kt
@@ -8,7 +8,10 @@ import com.futurae.sampleapp.utils.LocalStorage
 import com.futurae.sampleapp.home.accounts.AccountRowUIState
 import com.futurae.sampleapp.home.accounts.AccountsScreenUIState
 import com.futurae.sampleapp.home.accounts.restoreaccountsbanner.RestoreAccountsBannerUIState
+import com.futurae.sampleapp.home.accounts.usecase.GetEnrollmentExchangeTokensUseCase
 import com.futurae.sampleapp.home.accounts.usecase.GetTOTPUseCase
+import com.futurae.sampleapp.home.accounts.usecase.InitiateApp2AppEnrollmentUseCase
+import com.futurae.sdk.public_api.operations.model.EnrollmentExchangeTokenQrCode
 import com.futurae.sampleapp.ui.shared.elements.timeoutIndicator.startCountdown
 import com.futurae.sdk.FuturaeSDK
 import com.futurae.sdk.public_api.auth.model.SDKAuthMode
@@ -31,15 +34,24 @@ import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+import timber.log.Timber
 
-class AccountsViewModel(val getTOTPUseCase: GetTOTPUseCase) : ViewModel() {
+class AccountsViewModel(
+    val getTOTPUseCase: GetTOTPUseCase,
+    val initiateApp2AppEnrollmentUseCase: InitiateApp2AppEnrollmentUseCase,
+    val getEnrollmentExchangeTokensUseCase: GetEnrollmentExchangeTokensUseCase,
+) : ViewModel() {
 
     companion object {
         fun provideFactory(): ViewModelProvider.Factory = object : ViewModelProvider.Factory {
             @Suppress("UNCHECKED_CAST")
             override fun <T : ViewModel> create(
                 modelClass: Class<T>
-            ): T = AccountsViewModel(getTOTPUseCase = GetTOTPUseCase()) as T
+            ): T = AccountsViewModel(
+                getTOTPUseCase = GetTOTPUseCase(),
+                initiateApp2AppEnrollmentUseCase = InitiateApp2AppEnrollmentUseCase(),
+                getEnrollmentExchangeTokensUseCase = GetEnrollmentExchangeTokensUseCase(),
+            ) as T
         }
     }
 
@@ -65,6 +77,12 @@ class AccountsViewModel(val getTOTPUseCase: GetTOTPUseCase) : ViewModel() {
 
     private val _onHOTPGenerated = MutableSharedFlow<String>()
     val onHOTPGenerated = _onHOTPGenerated.asSharedFlow()
+
+    private val _onApp2AppEnrollmentInitiated = MutableSharedFlow<String>()
+    val onApp2AppEnrollmentInitiated = _onApp2AppEnrollmentInitiated.asSharedFlow()
+
+    private val _enrollmentQrCode = MutableStateFlow<EnrollmentExchangeTokenQrCode?>(null)
+    val enrollmentQrCode = _enrollmentQrCode.asStateFlow()
 
     private val _restorationBannerUIState = MutableStateFlow<RestoreAccountsBannerUIState>(RestoreAccountsBannerUIState.None)
     val restorationBannerUIState = _restorationBannerUIState.asStateFlow()
@@ -149,6 +167,30 @@ class AccountsViewModel(val getTOTPUseCase: GetTOTPUseCase) : ViewModel() {
                 FuturaeSDK.client.accountApi.logoutAccount(userId).await()
             }
         }
+    }
+
+    fun initiateApp2AppEnrollment(userId: String) {
+        viewModelScope.launch {
+            initiateApp2AppEnrollmentUseCase(userId)
+                .onSuccess { enrollmentInfo ->
+                    _onApp2AppEnrollmentInitiated.emit(enrollmentInfo.toString())
+                    getEnrollmentExchangeTokensUseCase(
+                        userId = userId,
+                        activationCodeShort = enrollmentInfo.activationCodeShort,
+                    ).onSuccess { tokens ->
+                        Timber.d("Enrollment exchange tokens count: ${tokens.size}")
+                        _enrollmentQrCode.value = tokens.getOrNull(3)
+                            .also { if (it == null) Timber.w("4th QR code not available, list size: ${tokens.size}") }
+                    }
+                }
+                .onFailure {
+                    Timber.d("Enrollment failure")
+                }
+        }
+    }
+
+    fun dismissEnrollmentQrCode() {
+        _enrollmentQrCode.value = null
     }
 
     private fun ILCEState<MigratableAccounts>.toRestorationBannerUIState(): RestoreAccountsBannerUIState {

--- a/futuraeSampleApp/src/main/java/com/futurae/sampleapp/home/accounts/usecase/GetEnrollmentExchangeTokensUseCase.kt
+++ b/futuraeSampleApp/src/main/java/com/futurae/sampleapp/home/accounts/usecase/GetEnrollmentExchangeTokensUseCase.kt
@@ -1,0 +1,30 @@
+package com.futurae.sampleapp.home.accounts.usecase
+
+import com.futurae.sdk.FuturaeSDK
+import com.futurae.sdk.public_api.operations.model.EnrollmentExchangeTokenQrCode
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import timber.log.Timber
+
+class GetEnrollmentExchangeTokensUseCase {
+
+    suspend operator fun invoke(
+        userId: String,
+        activationCodeShort: String,
+        totalExchangeTokens: Int = 4,
+        exchangeTokenLifetimeSeconds: Int = 60,
+    ): Result<List<EnrollmentExchangeTokenQrCode>> = withContext(Dispatchers.IO) {
+        try {
+            val tokens = FuturaeSDK.client.operationsApi.getEnrollmentExchangeTokens(
+                userId = userId,
+                activationCodeShort = activationCodeShort,
+                totalExchangeTokens = totalExchangeTokens,
+                exchangeTokenLifetimeSeconds = exchangeTokenLifetimeSeconds,
+            ).await()
+            Result.success(tokens)
+        } catch (t: Throwable) {
+            Timber.e(t)
+            Result.failure(t)
+        }
+    }
+}

--- a/futuraeSampleApp/src/main/java/com/futurae/sampleapp/home/accounts/usecase/InitiateApp2AppEnrollmentUseCase.kt
+++ b/futuraeSampleApp/src/main/java/com/futurae/sampleapp/home/accounts/usecase/InitiateApp2AppEnrollmentUseCase.kt
@@ -1,4 +1,19 @@
 package com.futurae.sampleapp.home.accounts.usecase
 
+import com.futurae.sdk.FuturaeSDK
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import timber.log.Timber
+
 class InitiateApp2AppEnrollmentUseCase {
+
+    suspend operator fun invoke(userId: String) = withContext(Dispatchers.IO) {
+        try {
+            val info = FuturaeSDK.client.operationsApi.spawnEnrollment(userId).await()
+            Result.success(info)
+        } catch (t: Throwable) {
+            Timber.e(t)
+            Result.failure(t)
+        }
+    }
 }

--- a/futuraeSampleApp/src/main/java/com/futurae/sampleapp/home/qrscanner/QRScannerScreen.kt
+++ b/futuraeSampleApp/src/main/java/com/futurae/sampleapp/home/qrscanner/QRScannerScreen.kt
@@ -13,6 +13,7 @@ import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableLongStateOf
@@ -26,7 +27,10 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.viewinterop.AndroidView
 import androidx.core.content.ContextCompat
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleEventObserver
 import androidx.lifecycle.LifecycleOwner
+import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.futurae.sampleapp.R
 import com.futurae.sampleapp.arch.AuthRequestData
@@ -60,6 +64,17 @@ fun QRScannerScreen(
     val cameraPermissionState = rememberPermissionState(Manifest.permission.CAMERA)
 
     var showGoToSettingsDialog by remember { mutableStateOf(false) }
+
+    val lifecycleOwner = LocalLifecycleOwner.current
+    DisposableEffect(lifecycleOwner) {
+        val observer = LifecycleEventObserver { _, event ->
+            if (event == Lifecycle.Event.ON_RESUME) {
+                qrScannerViewModel.onScreenResumed()
+            }
+        }
+        lifecycleOwner.lifecycle.addObserver(observer)
+        onDispose { lifecycleOwner.lifecycle.removeObserver(observer) }
+    }
 
     Box(
         modifier = Modifier.fillMaxSize(),

--- a/futuraeSampleApp/src/main/java/com/futurae/sampleapp/home/qrscanner/arch/QRScannerViewModel.kt
+++ b/futuraeSampleApp/src/main/java/com/futurae/sampleapp/home/qrscanner/arch/QRScannerViewModel.kt
@@ -36,15 +36,19 @@ class QRScannerViewModel : ViewModel() {
     private val _onEnrollmentFlowRequested = MutableSharedFlow<EnrollmentCase>()
     val onEnrollmentFlowRequest: SharedFlow<EnrollmentCase> = _onEnrollmentFlowRequested
 
+    private var isProcessingScan = false
+
     fun handleUserInteraction(userInteraction: QRScannerScreenUserInteraction) {
         when (userInteraction) {
             is QRScannerScreenUserInteraction.OnQRCodeScanned -> {
+                if (isProcessingScan) return
                 onQRCodeScanned(userInteraction.code)
             }
         }
     }
 
     private fun onQRCodeScanned(code: String) {
+        isProcessingScan = true
         when (val qrCode = FuturaeSDK.client.qrCodeApi.getQRCode(code)) {
             is QRCode.Enroll -> initiateEnrollmentFlow(code)
             is QRCode.Invalid -> notifyUserForInvalidQRCodeScanned()
@@ -59,12 +63,14 @@ class QRScannerViewModel : ViewModel() {
     private fun notifyForAuthRequest(authRequestData: AuthRequestData) {
         viewModelScope.launch {
             _onAuthRequest.emit(authRequestData)
+            isProcessingScan = false
         }
     }
 
     private fun initiateEnrollmentFlow(qrCode: String) {
         viewModelScope.launch {
             _onEnrollmentFlowRequested.emit(EnrollmentCase.ActivationCodeInput(qrCode))
+            isProcessingScan = false
         }
     }
 
@@ -86,6 +92,7 @@ class QRScannerViewModel : ViewModel() {
     private fun notifyUserForInvalidQRCodeScanned() {
         viewModelScope.launch {
             _onFailure.emit(Unit)
+            isProcessingScan = false
         }
     }
 
@@ -110,6 +117,8 @@ class QRScannerViewModel : ViewModel() {
             } catch (e: Throwable) {
                 Timber.e(e)
                 _onFailure.emit(Unit)
+            } finally {
+                isProcessingScan = false
             }
         }
     }
@@ -125,6 +134,8 @@ class QRScannerViewModel : ViewModel() {
             } catch (e: Throwable) {
                 Timber.e(e)
                 _onFailure.emit(Unit)
+            } finally {
+                isProcessingScan = false
             }
         }
     }

--- a/futuraeSampleApp/src/main/java/com/futurae/sampleapp/home/qrscanner/arch/QRScannerViewModel.kt
+++ b/futuraeSampleApp/src/main/java/com/futurae/sampleapp/home/qrscanner/arch/QRScannerViewModel.kt
@@ -38,6 +38,10 @@ class QRScannerViewModel : ViewModel() {
 
     private var isProcessingScan = false
 
+    fun onScreenResumed() {
+        isProcessingScan = false
+    }
+
     fun handleUserInteraction(userInteraction: QRScannerScreenUserInteraction) {
         when (userInteraction) {
             is QRScannerScreenUserInteraction.OnQRCodeScanned -> {
@@ -63,14 +67,12 @@ class QRScannerViewModel : ViewModel() {
     private fun notifyForAuthRequest(authRequestData: AuthRequestData) {
         viewModelScope.launch {
             _onAuthRequest.emit(authRequestData)
-            isProcessingScan = false
         }
     }
 
     private fun initiateEnrollmentFlow(qrCode: String) {
         viewModelScope.launch {
             _onEnrollmentFlowRequested.emit(EnrollmentCase.ActivationCodeInput(qrCode))
-            isProcessingScan = false
         }
     }
 
@@ -92,7 +94,6 @@ class QRScannerViewModel : ViewModel() {
     private fun notifyUserForInvalidQRCodeScanned() {
         viewModelScope.launch {
             _onFailure.emit(Unit)
-            isProcessingScan = false
         }
     }
 
@@ -117,8 +118,6 @@ class QRScannerViewModel : ViewModel() {
             } catch (e: Throwable) {
                 Timber.e(e)
                 _onFailure.emit(Unit)
-            } finally {
-                isProcessingScan = false
             }
         }
     }
@@ -134,8 +133,6 @@ class QRScannerViewModel : ViewModel() {
             } catch (e: Throwable) {
                 Timber.e(e)
                 _onFailure.emit(Unit)
-            } finally {
-                isProcessingScan = false
             }
         }
     }

--- a/futuraeSampleApp/src/main/res/values/strings.xml
+++ b/futuraeSampleApp/src/main/res/values/strings.xml
@@ -95,6 +95,9 @@
     <string name="delete_all_accounts">Delete All Accounts</string>
     <string name="delete_all_accounts_confirmation_dialog_title">Delete Accounts?</string>
     <string name="delete_all_accounts_confirmation_dialog_text">Please note that this action cannot be undone!</string>
+    <string name="app2app_enrollment">App2App Enrollment</string>
+    <string name="initiate_app2app_enrollment">Initiate App2App Enrollment</string>
+    <string name="app2app_enrollment_subtitle">Initiate App2App Enrollment to enroll an already enrolled account to a new device by scanning displayed QR code.</string>
     <string name="delete_all_accounts_confirmation_dialog_cancel_cta">Go Back</string>
     <string name="delete_all_accounts_confirmation_dialog_delete_cta">Delete</string>
     <string name="restore_accounts_subtitle">There are accounts backed up, and you can restore them here.</string>


### PR DESCRIPTION
**Summary**

Changes on sample app to support app2app enrollment flow.

A user can now long press on an enrolled account and initiate app2app enrollment, that would display a QR code that he/she should scan with the new device in order to enrolled the selected account to that device.